### PR TITLE
fix(config): cookie same_site is string type

### DIFF
--- a/src/core/Directus/Util/Installation/stubs/config.stub
+++ b/src/core/Directus/Util/Installation/stubs/config.stub
@@ -15,7 +15,7 @@ return [
     ],
 
     'cookie' => [
-        'same_site' => {{cookie.same_site}},
+        'same_site' => '{{cookie.same_site}}',
         'secure' => {{cookie.secure}}
     ],
 


### PR DESCRIPTION
When I use Docker to build the environment, I get an undefined constant Lax error.